### PR TITLE
Refactored ImageFormatCompilerPass to meet the requirements of the new image formats definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-develop
+    * ENHANCEMENT #2 Refactored ImageFormatCompilerPass to meet the requirements of the new image formats definition
+
 * 1.0.0 (2016-07-22)
-    * FEATURE #1 Introduced liip/theme-bundle to enable theming
+    * FEATURE     #1 Introduced liip/theme-bundle to enable theming


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | - |
| Related issues/PRs | https://github.com/sulu/sulu/pull/2845 |
| License | MIT |
| Documentation PR | - |
#### What's in this PR?

There is PR (https://github.com/sulu/sulu/pull/2845) which introduces a new version for the definition of image-formats. This PR updates the ThemeBundle to meet the requirements of the new version.
