### PR TITLE
fixed setting a theme for exception pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * BUGFIX      #6 Fixed setting a theme for exception pages
+
 * 1.2.0-RC1 (2017-02-13)
     * ENHANCEMENT #5 Updated composer dependencies
     * BUGFIX      #4 Removed duplicated logic already existing in Sulu

--- a/EventListener/SetThemeEventListener.php
+++ b/EventListener/SetThemeEventListener.php
@@ -40,8 +40,7 @@ class SetThemeEventListener
      */
     public function setActiveThemeOnRequest(GetResponseEvent $event)
     {
-        if (!$event->isMasterRequest()
-            || null === ($attributes = $event->getRequest()->get('_sulu'))
+        if (null === ($attributes = $event->getRequest()->get('_sulu'))
             || null === ($webspace = $attributes->getAttribute('webspace'))
             || null === ($theme = $webspace->getTheme())
         ) {

--- a/Tests/Unit/EventListener/SetThemeEventListenerTest.php
+++ b/Tests/Unit/EventListener/SetThemeEventListenerTest.php
@@ -69,11 +69,15 @@ class SetThemeEventListenerTest extends \PHPUnit_Framework_TestCase
     public function testEventListenerNotMaster()
     {
         $request = $this->prophesize(Request::class);
-        $event = $this->prophesize(GetResponseEvent::class);
-        $event->isMasterRequest()->willReturn(false);
-        $event->getRequest()->willReturn($request->reveal());
+        $attributes = $this->prophesize(RequestAttributes::class);
+        $attributes->getAttribute('webspace')->willReturn($this->webspace->reveal());
+        $request->get('_sulu')->willReturn($attributes->reveal());
 
-        $this->activeTheme->setName($this->theme)->shouldNotBeCalled();
+        $event = $this->prophesize(GetResponseEvent::class);
+        $event->getRequest()->willReturn($request->reveal());
+        $event->isMasterRequest()->willReturn(false);
+
+        $this->activeTheme->setName($this->theme)->shouldBeCalled();
 
         $this->listener->setActiveThemeOnRequest($event->reveal());
     }


### PR DESCRIPTION
The theme listener returns early if the given request is not a master request. And this is the case if an [exception is handled](https://github.com/symfony/symfony/blob/3.2/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php#L50). Seems like it has always been like that.

This needs to be fixed, in order to be working for stuff like 404 error pages.