### PR TITLE
Fix preview webspace without theme

### DIFF
--- a/EventListener/SetThemeEventListener.php
+++ b/EventListener/SetThemeEventListener.php
@@ -60,7 +60,10 @@ class SetThemeEventListener
      */
     public function setActiveThemeOnPreviewPreRender(PreRenderEvent $event): void
     {
-        $theme = $this->themeRepository->findOneByName($event->getAttribute('webspace')->getTheme());
+        if (null === $themeName = $event->getAttribute('webspace')->getTheme()) {
+            return;
+        }
+        $theme = $this->themeRepository->findOneByName($themeName);
         if (null !== $theme) {
             $this->themeContext->setTheme($theme);
         }

--- a/EventListener/SetThemeEventListener.php
+++ b/EventListener/SetThemeEventListener.php
@@ -60,7 +60,8 @@ class SetThemeEventListener
      */
     public function setActiveThemeOnPreviewPreRender(PreRenderEvent $event): void
     {
-        if (null === $themeName = $event->getAttribute('webspace')->getTheme()) {
+        $themeName = $event->getAttribute('webspace')->getTheme();
+        if (null === $themeName) {
             return;
         }
         $theme = $this->themeRepository->findOneByName($themeName);

--- a/Tests/Unit/EventListener/SetThemeEventListenerTest.php
+++ b/Tests/Unit/EventListener/SetThemeEventListenerTest.php
@@ -173,4 +173,24 @@ class SetThemeEventListenerTest extends TestCase
 
         $this->assertSame($theme->reveal(), $this->themeContext->getTheme());
     }
+
+    public function testEventListenerOnPreviewNoTheme(): void
+    {
+        /** @var Webspace|ObjectProphecy webspace */
+        $webspace = $this->prophesize(Webspace::class);
+        $webspace->getTheme()->willReturn(null);
+
+        /** @var RequestAttributes|ObjectProphecy $attributes */
+        $attributes = $this->prophesize(RequestAttributes::class);
+        $attributes->getAttribute('webspace', null)->willReturn($webspace->reveal());
+
+        $this->themeRepository->findOneByName('theme/name')
+            ->shouldNotBeCalled();
+
+        $this->listener->setActiveThemeOnPreviewPreRender(
+            new PreRenderEvent($attributes->reveal())
+        );
+
+        $this->assertNull($this->themeContext->getTheme());
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Fix for preview when no theme is specified in a webspace. 

#### Why?

If no theme is specified default template dir must be used

#### Example Usage

Create a webspace without theme and try to preview a page in admin.
