### PR TITLE
Fix for including theme image format config

### DIFF
--- a/DependencyInjection/CompilerPass/ImageFormatCompilerPass.php
+++ b/DependencyInjection/CompilerPass/ImageFormatCompilerPass.php
@@ -34,6 +34,11 @@ class ImageFormatCompilerPass extends AbstractImageFormatCompilerPass
 
         $files = [];
         foreach ($themeRepository->findAll() as $theme) {
+            // Add theme config if exists
+            if (\file_exists($theme->getPath() . '/' . $configPath)) {
+                $files[] = $theme->getPath() . '/' . $configPath;
+            }
+
             foreach ($bundles as $bundle) {
                 $bundleReflection = new \ReflectionClass($bundle);
                 $fileName = $bundleReflection->getFileName();

--- a/Tests/Application/theme/config/image-formats.xml
+++ b/Tests/Application/theme/config/image-formats.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<formats xmlns="http://schemas.sulu.io/media/formats"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://schemas.sulu.io/media/formats http://schemas.sulu.io/media/formats-1.1.xsd">
+
+    <format key="600x">
+        <meta>
+            <title lang="en">Example Image</title>
+            <title lang="de">Beispielbild</title>
+        </meta>
+
+        <scale x="600"/>
+    </format>
+</formats>

--- a/Tests/Unit/DependencyInjection/CompilerPass/ImageFormatCompilerPassTest.php
+++ b/Tests/Unit/DependencyInjection/CompilerPass/ImageFormatCompilerPassTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ThemeBundle\Tests\Unit\DependencyInjection\CompilerPass;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\ThemeBundle\DependencyInjection\CompilerPass\ImageFormatCompilerPass;
+use Sylius\Bundle\ThemeBundle\Model\ThemeInterface;
+use Sylius\Bundle\ThemeBundle\Repository\ThemeRepositoryInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ImageFormatCompilerPassTest extends TestCase
+{
+    /**
+     * @var ThemeRepositoryInterface|ObjectProphecy
+     */
+    private $themeRepository;
+
+    /**
+     * @var ContainerBuilder
+     */
+    private $container;
+
+    /**
+     * @var ImageFormatCompilerPass
+     */
+    private $compilerPass;
+
+    protected function setUp(): void
+    {
+        $this->themeRepository = $this->prophesize(ThemeRepositoryInterface::class);
+
+        $this->container = new ContainerBuilder();
+        $this->container->setParameter('sulu_media.format_manager.default_imagine_options', []);
+        $this->container->setParameter('kernel.bundles', []);
+        $this->container->set('sylius.repository.theme', $this->themeRepository->reveal());
+
+        $this->compilerPass = new ImageFormatCompilerPass();
+    }
+
+    public function testGetFiles(): void
+    {
+        /** @var ThemeInterface|ObjectProphecy $theme */
+        $theme = $this->prophesize(ThemeInterface::class);
+        $theme->getPath()
+            ->willReturn('Tests/Application/theme')
+            ->shouldBeCalled();
+
+        $this->themeRepository
+            ->findAll()
+            ->willReturn([$theme->reveal()])
+            ->shouldBeCalled();
+
+        $this->compilerPass->process($this->container);
+
+        $formats = $this->container->getParameter('sulu_media.image.formats');
+
+        $this->assertCount(1, $formats);
+        // @phpstan-ignore-next-line
+        $this->assertArrayHasKey('600x', $formats);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #16
| License | MIT

#### What's in this PR?

In the documentation [here](https://docs.sulu.io/en/latest/book/image-formats.html) is described here:

> Or when you use the SuluThemeBundle you can define the formats in your theme folder:
> 
> path/to/<theme>/config/image-formats.xml

This doesn't appear to work as described

#### Why?

This pull requests will add the described option and will allow an image-format.xml file per theme.

