### PR TITLE
Upgrade PHPUnit and add PHP 8.4 to CI

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -23,11 +23,13 @@ jobs:
                 include:
                     - php-version: '7.3'
                       dependency-versions: 'lowest'
+                      phpunit-config: 'phpunit-9.xml.dist'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: disabled
 
                     - php-version: '7.4'
                       dependency-versions: 'highest'
+                      phpunit-config: 'phpunit-9.xml.dist'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
 
@@ -48,6 +50,12 @@ jobs:
 
                     - php-version: '8.3'
                       dependency-versions: 'highest'
+                      env:
+                          SYMFONY_DEPRECATIONS_HELPER: weak
+
+                    - php-version: '8.4'
+                      dependency-versions: 'highest'
+                      composer-options: '--ignore-platform-reqs'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
 
@@ -79,13 +87,14 @@ jobs:
               uses: ramsey/composer-install@v2
               with:
                   dependency-versions: ${{matrix.dependency-versions}}
+                  composer-options: ${{ matrix.composer-options }}
 
             - name: Bootstrap test environment
               run: composer bootstrap-test-environment
               env: ${{ matrix.env }}
 
             - name: Execute test cases
-              run: time composer test
+              run: time composer test -- --config ${{ matrix.phpunit-config || 'phpunit.xml.dist' }}
               env: ${{ matrix.env }}
 
     lint:

--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,9 @@
         "phpstan/phpstan-doctrine": "^1.2",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpstan/phpstan-symfony": "^1.1",
-        "phpunit/phpunit": "^8.5.9 || ^9.5",
+        "phpunit/phpunit": "^9.6 || ^10.0",
         "symfony/dotenv": "^5.4 || ^6.0 || ^7.0",
         "symfony/monolog-bundle": "^3.1",
-        "symfony/phpunit-bridge": "^5.2 || ^6.0 || ^7.0",
         "thecodingmachine/phpstan-strict-rules": "^1.0"
     },
     "conflict": {

--- a/phpunit-9.xml.dist
+++ b/phpunit-9.xml.dist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="Tests/test-bootstrap.php" colors="true">
+
+    <testsuites>
+        <testsuite name="SuluThemeBundle Test Suite">
+            <directory suffix="Test.php">./Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
+    <php>
+        <env name="KERNEL_CLASS" value="Sulu\Bundle\ThemeBundle\Tests\Application\Kernel"/>
+        <env name="APP_ENV" value="test" force="true"/>
+    </php>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,29 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="Tests/test-bootstrap.php" colors="true">
-
     <testsuites>
-        <testsuite name="SuluThemeBundle Test Suite">
-            <directory suffix="Test.php">./Tests</directory>
+        <testsuite name="Sulu Theme Bundle">
+            <directory>./Tests</directory>
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-
     <php>
-        <env name="SYMFONY_PHPUNIT_VERSION" value="8.0"/>
-        <env name="APP_ENV" value="test"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <env name="KERNEL_CLASS" value="Sulu\Bundle\ThemeBundle\Tests\Application\Kernel"/>
+        <env name="APP_ENV" value="test" force="true"/>
     </php>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
-    </listeners>
+    <source>
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>Resources/</directory>
+            <directory>Tests/</directory>
+            <directory>vendor/</directory>
+        </exclude>
+    </source>
 </phpunit>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Upgrade PHPUnit and add PHP 8.4 to CI.

#### Why?

Preparing Symfony 7 release and test the CI.

