### PR TITLE
Add Sulu 3.0 support increase min PHP Version to 8.2 and Sulu to 2.6.10

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -55,6 +55,12 @@ jobs:
 
                     - php-version: '8.4'
                       dependency-versions: 'highest'
+                      env:
+                          SYMFONY_DEPRECATIONS_HELPER: weak
+
+                    - php-version: '8.4'
+                      dependency-versions: 'highest'
+                      composer-stability: 'dev'
                       composer-options: '--ignore-platform-reqs'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
@@ -82,6 +88,10 @@ jobs:
               # These tools are not required to run tests, so we are removing them to improve dependency resolving and
               # testing lowest versions.
               run: composer remove "*php-cs-fixer*" "*phpstan*" "*rector*" --dev --no-update
+
+            - name: Set composer stability
+              if: ${{ matrix.composer-stability }}
+              run: composer config minimum-stability ${{ matrix.composer-stability }}
 
             - name: Install composer dependencies
               uses: ramsey/composer-install@v2

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -21,27 +21,10 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - php-version: '7.3'
+                    - php-version: '8.2'
                       dependency-versions: 'lowest'
-                      phpunit-config: 'phpunit-9.xml.dist'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: disabled
-
-                    - php-version: '7.4'
-                      dependency-versions: 'highest'
-                      phpunit-config: 'phpunit-9.xml.dist'
-                      env:
-                          SYMFONY_DEPRECATIONS_HELPER: weak
-
-                    - php-version: '8.0'
-                      dependency-versions: 'highest'
-                      env:
-                          SYMFONY_DEPRECATIONS_HELPER: weak
-
-                    - php-version: '8.1'
-                      dependency-versions: 'highest'
-                      env:
-                          SYMFONY_DEPRECATIONS_HELPER: weak
 
                     - php-version: '8.2'
                       dependency-versions: 'highest'

--- a/Tests/Application/Kernel.php
+++ b/Tests/Application/Kernel.php
@@ -41,6 +41,19 @@ class Kernel extends SuluTestKernel
         parent::registerContainerConfiguration($loader);
 
         $loader->load(__DIR__ . '/config/config_' . $this->getContext() . '.yaml');
+
+        $bundles = $this->registerBundles();
+        $hasMassiveSearchBundle = false;
+        foreach ($bundles as $bundle) {
+            if ($bundle instanceof \Massive\Bundle\SearchBundle\MassiveSearchBundle) {
+                $hasMassiveSearchBundle = true;
+                break;
+            }
+        }
+
+        if ($hasMassiveSearchBundle) {
+            $loader->load(__DIR__ . '/config/config_massive_search.yaml');
+        }
     }
 
     protected function getKernelParameters(): array

--- a/Tests/Application/config/config.yaml
+++ b/Tests/Application/config/config.yaml
@@ -7,6 +7,3 @@ doctrine:
                 dir: "%gedmo_directory%/Tree/Entity"
                 alias: GedmoTree
                 is_bundle: false
-
-massive_search:
-    adapter: test

--- a/Tests/Application/config/config_massive_search.yaml
+++ b/Tests/Application/config/config_massive_search.yaml
@@ -1,0 +1,2 @@
+massive_search:
+    adapter: test

--- a/Tests/Application/config/routing_admin.yaml
+++ b/Tests/Application/config/routing_admin.yaml
@@ -1,3 +1,3 @@
 sulu_admin:
-    resource: "@SuluAdminBundle/Resources/config/routing.yml"
+    resource: "@SuluAdminBundle/Resources/config/routing.yaml"
     prefix: /admin

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "sulu/sulu": "^2.4 || ^2.6@dev || ^3.0 || ^3.0@dev",
+        "sulu/sulu": "^2.6.10 || ^2.6@dev || ^3.0 || ^3.0@dev",
         "symfony/config": "^4.4 || ^5.4 || ^6.0 || ^7.0",
         "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.0 || ^7.0",
         "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "sulu/sulu": "^2.4 || ^2.5@dev",
+        "sulu/sulu": "^2.4 || ^3.0 || ^3.0@alpha || ^3.0@dev || ^2.5@dev",
         "symfony/config": "^4.4 || ^5.4 || ^6.0 || ^7.0",
         "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.0 || ^7.0",
         "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "sulu/sulu": "^2.4 || ^3.0 || ^3.0@alpha || ^3.0@dev || ^2.5@dev",
+        "sulu/sulu": "^2.4 || ^2.6@dev || ^3.0 || ^3.0@dev",
         "symfony/config": "^4.4 || ^5.4 || ^6.0 || ^7.0",
         "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.0 || ^7.0",
         "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^8.2",
         "sulu/sulu": "^2.6.10 || ^2.6@dev || ^3.0 || ^3.0@dev",
-        "symfony/config": "^4.4 || ^5.4 || ^6.0 || ^7.0",
-        "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.0 || ^7.0",
+        "symfony/config": "^5.4 || ^6.0 || ^7.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
         "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
         "sylius/theme-bundle": "^2.1 || ^2.4@dev"
     },


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR add sulu 3.0 support to the bundle.

#### Why?

When we want to use this in sulu 3.0 we have to upgrade it :)

#### To Do

- [ ] Fix testcases
