### PR TITLE
Fix test lowest correctly against Sulu 2.6 by install jackalope-doctrine-dbal adapter

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -77,6 +77,10 @@ jobs:
               # testing lowest versions.
               run: composer remove "*php-cs-fixer*" "*phpstan*" "*rector*" --dev --no-update
 
+            - name: "Ensuring the tests also run with jackalope<2"
+              if: ${{ matrix.dependency-versions == 'lowest' }}
+              run: composer require jackalope/jackalope-doctrine-dbal:">=1.6" --no-update
+
             - name: Install composer dependencies
               uses: ramsey/composer-install@v2
               with:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?
Adding tests for jackalope 1.6 for Sulu 2.6

#### Why?
Testing that both things work at the same time.