### PR TITLE
Remove lowest dev version

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -58,6 +58,13 @@ jobs:
                           SYMFONY_DEPRECATIONS_HELPER: weak
                           DATABASE_URL: mysql://root:ChangeMe@127.0.0.1:3306/su_theme_test?serverVersion=8.4
 
+                    - php-version: '8.5'
+                      database: mysql-84
+                      dependency-versions: 'highest'
+                      env:
+                          SYMFONY_DEPRECATIONS_HELPER: weak
+                          DATABASE_URL: mysql://root:ChangeMe@127.0.0.1:3306/su_theme_test?serverVersion=8.4
+
         steps:
             - name: Checkout project
               uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "sulu/sulu": "^2.6.10 || ^2.6@dev || ^3.0 || ^3.0@dev",
+        "sulu/sulu": "^2.6.10 || ^3.0 || ^3.0.1@dev",
         "symfony/config": "^5.4 || ^6.4 || ^7.0",
         "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.0",
         "symfony/http-kernel": "^5.4 || ^6.4 || ^7.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Remove lowest dev version.

#### Why?

The `@dev` is just added to run tests on newest dev version. Which is not needed for 2.6 constraint.